### PR TITLE
Fail workflow version registration when attempting to update workflow version

### DIFF
--- a/scripts/vidarr-build
+++ b/scripts/vidarr-build
@@ -206,7 +206,10 @@ for registration_url in registration_urls:
             f"Failed to register workflow version on {registration_url}: {res.status_code} {res.json()}")
         ok = False
     elif res.status_code in [409]:
-        print(f"This workflow version has already been installed on {registration_url}")
+        print(f"This workflow version is different from the workflow version with the same name + version on {registration_url}")
+        ok = False
+    elif res.status_code in [200]:
+        print(f"Workflow version is already registered on {registration_url}")
         registered = True
     else:
         print(f"Registered on {registration_url}!")

--- a/scripts/vidarr-build
+++ b/scripts/vidarr-build
@@ -203,7 +203,8 @@ for registration_url in registration_urls:
     res = requests.post(registration_url, json=workflow)
     if res.status_code not in [200, 201, 409]:
         print(
-            f"Failed to register workflow version on {registration_url}: {res.status_code} {res.json()}")
+            f"Failed to register workflow version on {registration_url}: response status {res.status_code}}")
+        print(f"{res.json() if res.content}")  # only read the response body if it is not empty
         ok = False
     elif res.status_code in [409]:
         print(f"This workflow version is different from the workflow version with the same name + version on {registration_url}")


### PR DESCRIPTION
Workflow versions are immutable. If the submitted workflow version differs from the existing workflow version, the request should fail. (Previously, it was assumed that of course the workflow version would be the same, but this PR enforces that assumption)
GP-3138

This should be merged once this Vidarr PR is merged: https://github.com/oicr-gsi/vidarr/pull/142