### PR TITLE
updated READMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,13 +162,13 @@ vidarr-build requires that the directory containing vidarrbuild.json also contai
 
 Builds the workflow using the specified language's build process and performs regression specified by `vidarrtest-regression.json` and optionally performance tests specified by `vidarrtest-performance.json`. See [Test configuration](#test-configuration). Additionally there is an optional argument to provide an explicit output directory for those test outputs. 
 
-| Argument                   | Required? | Default Value | Description                                                                                             |
-|----------------------------|-|-|---------------------------------------------------------------------------------------------------------|
-| `--build-config`, `-c`     | False | `vidarrbuild.json` | Specify the build file location. See [vidarrbuild.json](#vidarrbuildjson)                               |
-| `--test-config`, `t`       | True | Environment variable `VIDARR_TEST_CONFIG` | Víðarr configuration file for running tests                                                             |
+| Argument             | Required? | Default Value | Description                                                                                             |
+|----------------------|-|-|---------------------------------------------------------------------------------------------------------|
+| `--build-config`, `-c` | False | `vidarrbuild.json` | Specify the build file location. See [vidarrbuild.json](#vidarrbuildjson)                               |
+| `--test-config`, `t` | True | Environment variable `VIDARR_TEST_CONFIG` | Víðarr configuration file for running tests                                                             |
 | `--performance-test`, `-p` | False | | Run performance tests specified by `vidarrtest-performance.json`                                        |
 | `--output-directory`, `-o` | False | | Provide an explicit output directory for the test output files e.g. `/scratch2/groups/gsi/development/` |
-| `--verbose`, `-v`          | False | | Verbose mode flag helpful for debugging                                                                 |
+| `--verbose`          | False | | Verbose mode flag helpful for debugging                                                                 |
 
 vidarr-build will output the result of the specified language's processor and test results at `v.out`. 
 
@@ -230,5 +230,7 @@ Builds the workflow using the specified language's build process and performs re
 | `--url`, `-u` | False | Environment variable `VIDARR_URLS` | A Víðarr server to deploy to. If unspecified, the servers from the space-separated environment variable VIDARR_URLS will be used. |
 | `--url-file`, `-U` | False | | A file containing Víðarr servers to deploy to (one per line). |
 | `--version`, `-v` | True | | The version number to push as. See [Víðarr's glossary](https://github.com/oicr-gsi/vidarr/blob/master/glossary.md) |
+| `--output-directory`, `-o` | False | | Provide an explicit output directory for the test output files e.g. `/scratch2/groups/gsi/development/` |
+| `--verbose`          | False | | Verbose mode flag helpful for debugging                                                                 |
 
 vidarr-build will output the result of the specified language's processor and test output at `v.out`, then push the resultant build to the Víðarr instances specified by `--url` and/or `--url-file`. 


### PR DESCRIPTION
Updating README for vidarr-tools

- Added output directory and verbose in vidarr-build deploy documentation. 
- Removed -v from test-parse to only support --verbose for argparse verbose